### PR TITLE
Add screenshot and translation management features

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "react-app",
       "version": "0.0.0",
       "dependencies": {
+        "html2canvas": "^1.4.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1834,6 +1835,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1983,6 +1993,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -2458,6 +2477,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/ignore": {
@@ -3372,6 +3404,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -3441,6 +3482,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "html2canvas": "^1.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import html2canvas from 'html2canvas';
 import './index.css';
 import '../header.css';
 import '../footer.css';
@@ -81,6 +82,17 @@ export default function App() {
     });
   };
 
+  const captureScreenshot = () => {
+    const node = document.getElementById('uiContainer');
+    if (!node) return;
+    html2canvas(node).then(canvas => {
+      const link = document.createElement('a');
+      link.href = canvas.toDataURL('image/png');
+      link.download = 'screenshot.png';
+      link.click();
+    });
+  };
+
   return (
     <div style={{ minHeight: '100vh', backgroundColor: settings.backgroundColor, backgroundImage: `url(${settings.backgroundImage})`, backgroundSize: 'cover' }}>
       <div className="header">
@@ -103,7 +115,29 @@ export default function App() {
               <input name="approved" type="number" min="0" max="100" defaultValue="0" className="p-1 rounded text-black" />
               <button type="submit" className="bg-[#7e292a] rounded p-2 mt-2">Додати</button>
             </form>
-            <div className="removeobj"></div>
+            <div className="removeobj space-y-2">
+              {items.map(item => (
+                <div key={item.id} className="removecont text-white">
+                  <div className="removetextcont">
+                    <div className="contcont">
+                      <div className="removebtn" title="remove" onClick={() => removeItem(item.id)}>
+                        <i className="emoji em-delete"></i>
+                      </div>
+                      <div className="nameUI">
+                        <div className="itemimage" style={{ background: `url('${item.image}')` }}></div>
+                        <div>{item.id}</div>
+                      </div>
+                    </div>
+                  </div>
+                  <label className="text-sm">Назва:</label>
+                  <input type="text" className="title-edit-input p-1 rounded text-black" value={item.title} onChange={e => updateItem(item.id, 'title', e.target.value)} />
+                  <label className="text-sm">✏️ Перекладено:</label>
+                  <input type="number" min="0" max="100" className="translated-input form__label p-1 rounded text-black" value={item.translated} onChange={e => updateItem(item.id, 'translated', Number(e.target.value))} />
+                  <label className="text-sm">✅ Затверджено:</label>
+                  <input type="number" min="0" max="100" className="approved-input form__label p-1 rounded text-black" value={item.approved} onChange={e => updateItem(item.id, 'approved', Number(e.target.value))} />
+                </div>
+              ))}
+            </div>
           </div>
           <div className="flex-1 flex flex-col gap-4">
             <form className="SiteSettings bg-[#26292f] p-4 rounded text-white flex flex-col gap-2">
@@ -125,7 +159,7 @@ export default function App() {
             </form>
           </div>
         </div>
-        <div className="UI w-full max-w-5xl mt-6">
+        <div id="uiContainer" className="UI w-full max-w-5xl mt-6">
           <div className="images flex flex-wrap justify-center gap-4" style={{ gap: `${settings.imageGap}px` }}>
             {items.map(item => (
               <div key={item.id} className="itemcontainer p-2" style={{ width: settings.cardSize + 'px' }}>
@@ -151,10 +185,15 @@ export default function App() {
             ))}
           </div>
         </div>
-        <div className="capture text-center mt-6">
+        <div className="capture text-center mt-6 space-x-2">
           <button onClick={copyText} className="bg-[#7e292a] text-white rounded px-4 py-2">Скопіювати записи</button>
+          <button onClick={captureScreenshot} className="bg-[#7e292a] text-white rounded px-4 py-2">Зробити знімок</button>
         </div>
-        <div id="perctext"></div>
+        <div id="perctext" className="text-white mt-4">
+          {items.map(it => (
+            <div key={it.id}>{`${it.title}: ${it.translated}%✏️ ${it.approved}%✅`}</div>
+          ))}
+        </div>
         <canvas id="output" style={{ display: 'none' }}></canvas>
       </div>
       <div className="footer">


### PR DESCRIPTION
## Summary
- enable screenshot capture via html2canvas
- show translation management list under the add form
- provide screenshot button and list of translation texts
- record items in translation zone with ability to edit or remove

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d5125b0608332804961b53c2c549c